### PR TITLE
Update nodejs plan

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -1,4 +1,4 @@
 #include <turnkey/base>
-#include <turnkey/nodejs>
+#include <turnkey/nodejs-nginx>
 
 redis-server


### PR DESCRIPTION
Update nodejs plan (old `nodejs` plan no longer has nginx).

Part of https://github.com/turnkeylinux/tracker/issues/1772

Also requires:

- https://github.com/turnkeylinux/common/pull/231
- https://github.com/turnkeylinux-apps/etherpad/pull/18
- https://github.com/turnkeylinux-apps/ghost/pull/16
- https://github.com/turnkeylinux-apps/mongodb/pull/20
- https://github.com/turnkeylinux-apps/nodejs/pull/15